### PR TITLE
Tasklist, Storage and Parser class: Add assertions

### DIFF
--- a/src/main/java/brobot/Storage.java
+++ b/src/main/java/brobot/Storage.java
@@ -92,6 +92,8 @@ public class Storage {
      */
     public void writeList(TaskList list) {
         try {
+            assert(new File(filePath).exists());
+            assert(new File(filePath).canWrite());
             FileWriter fw = new FileWriter(filePath);
             fw.write(list.toStorageString());
             fw.close();

--- a/src/main/java/brobot/parser/BroParser.java
+++ b/src/main/java/brobot/parser/BroParser.java
@@ -106,6 +106,7 @@ public class BroParser {
             NoSuchTaskException {
         if (inputScanner.hasNextInt()) {
             int taskPos = inputScanner.nextInt() - 1;
+            assert(taskPos >= 0);
             list.markDone(taskPos);
             storage.writeList(list);
             return UI.getTaskDoneText(list.getTask(taskPos + 1));

--- a/src/main/java/brobot/task/TaskList.java
+++ b/src/main/java/brobot/task/TaskList.java
@@ -33,6 +33,7 @@ public class TaskList {
      * @return The Task.
      */
     public Task getTask(int taskNumber) {
+        assert(taskNumber > 0);
         return this.list.get(taskNumber - 1);
     }
 
@@ -52,6 +53,7 @@ public class TaskList {
      * @throws NoSuchTaskException
      */
     public void markDone(int taskPos) throws NoSuchTaskException {
+        assert(taskPos >= 0);
         if (taskPos >= 0 && taskPos < list.size()) {
             list.get(taskPos).markComplete();
         } else {
@@ -67,7 +69,7 @@ public class TaskList {
      * @throws NoSuchTaskException
      */
     public Task deleteTask(int taskPos) throws NoSuchTaskException {
-
+        assert(taskPos >= 0);
         if (taskPos >= 0 && taskPos < list.size()) {
             Task temp = list.get(taskPos);
             list.remove(taskPos);


### PR DESCRIPTION
The above-mentioned classes make unchecked assumptions such as the
taskNUmber being more than 0 and the filePath being writable in storage

Should these criterias not be checked and indeed fail, there could be serious
bugs occuring during runtime.

I will add assertions to check for the assumptions made in Tasklist,
Storage and Parser class to ensure that the program stops if these
assumptions are not met.